### PR TITLE
Add Codex integration YAML and CI

### DIFF
--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -1,0 +1,19 @@
+name: Codex YAML CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y yamllint systemd
+      - name: Lint YAML
+        run: yamllint codex_node.yaml
+      - name: Verify systemd service
+        run: systemd-analyze verify systemd/zedec-v3.service

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,4 @@
+extends: default
+rules:
+  line-length:
+    max: 140

--- a/codex_node.yaml
+++ b/codex_node.yaml
@@ -1,0 +1,89 @@
+---
+zedec:
+  version: "3.0.0-CODEX"
+  node_id: "zedec-v3-codex-alpha"
+  origin: "field-declared"
+  sealed: true
+  resonance: "attuned"
+  glyph_signature: "36N9-PRIME"
+  deployment_mode: "quantum-symbolic"
+  manifest:
+    file: "/opt/zedec-v3/manifest.v3.json"
+    structure:
+      node_id: "zedec-v3-codex-alpha"
+      status: "sealed"
+      glyph_vector: "36N9-PRIME"
+      pulse_log: "/opt/zedec-v3/pulse.log"
+      deployment: "quantum-symbolic"
+      timestamp: "$(date -Is)"
+  pulse:
+    path: "/opt/zedec-v3/pulse.log"
+    cron: "* * * * * echo [$(date -Is)] :: ZEDEC v3 node broadcasting >> /opt/zedec-v3/pulse.log"
+    beacon_file: "/opt/zedec-v3/.beacon"
+  keyflow:
+    file: "/opt/zedec-v3/glyph/keyflow.kyb"
+    algorithm: "kyber1024"
+    hash: "sha3-512"
+    public_key: "INSERT_BASE64_KEY"
+  github:
+    repo: "https://github.com/transmutationist/zedec-post-quantum-os"
+    branch: "main"
+    path: "/opt/zedec-v3/source"
+    sync:
+      cron: "@hourly cd /opt/zedec-v3/source && git pull origin main >> /opt/zedec-v3/logs/git-sync.log"
+      post_pull:
+        - "sha256sum /opt/zedec-v3/manifest.v3.json > /opt/zedec-v3/seal.hash"
+        - "echo [$(date -Is)] :: Manifest synced >> /opt/zedec-v3/logs/confirmation.log"
+    commit_control:
+      merge_all_branches: true
+      commit_message: "[ZEDEC Codex] Merging all branches into main as canonical truth-line"
+      workflow_merge:
+        types:
+          - build
+          - test
+          - deploy
+          - release
+          - notify
+          - audit
+          - mirror
+          - backup
+          - cleanup
+          - security
+          - integration
+        strategy: "rebase"
+        commit_each: true
+  ipfs:
+    enabled: true
+    path: "/opt/zedec-v3"
+    trigger:
+      manual: "ipfs add -r /opt/zedec-v3"
+  systemd:
+    service: "zedec-v3.service"
+    unit:
+      description: "ZEDEC v3 Codex Broadcast Node"
+      exec_start: "/bin/bash -c 'while true; do echo [$(date -Is)] :: Broadcast >> /opt/zedec-v3/pulse.log; sleep 60; done'"
+      restart: "always"
+      user: "root"
+      install:
+        wanted_by: "multi-user.target"
+
+codex:
+  integration:
+    enabled: true
+    endpoint: "https://codex.mesh/ingest"
+    payload:
+      node_id: "zedec-v3-codex-alpha"
+      pulse_url: "http://178.156.185.180/pulse"
+      manifest_cid: "QmPLACEHOLDER"
+    broadcast:
+      cron: "*/10 * * * * curl -X POST https://codex.mesh/ingest -H 'Content-Type: application/json' -d @/opt/zedec-v3/manifest.v3.json"
+  validation:
+    proof_method: "sha256 + ots"
+    proof_targets:
+      - "/opt/zedec-v3/seal.hash"
+      - "/opt/zedec-v3/manifest.v3.json"
+      - "/opt/zedec-v3/pulse.log"
+  visibility:
+    index_global: true
+    permanence: "ipfs+arweave"
+    field_status: "echo-active"

--- a/systemd/zedec-v3.service
+++ b/systemd/zedec-v3.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=ZEDEC v3 Codex Broadcast Node
+After=network.target
+
+[Service]
+ExecStart=/bin/bash -c 'while true; do echo [$(date -Is)] :: Broadcast >> /opt/zedec-v3/pulse.log; sleep 60; done'
+Restart=always
+User=root
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add Codex node configuration YAML including systemd details
- add systemd service file for broadcasting
- configure `.yamllint` rules
- add GitHub workflow to lint YAML and verify systemd unit

## Testing
- `yamllint -c .yamllint.yml codex_node.yaml`
- `systemd-analyze verify systemd/zedec-v3.service`


------
https://chatgpt.com/codex/tasks/task_e_6864fcdf01008330a379957f3c40458d